### PR TITLE
Feat: Add test plugin and tests for pluggable service overrides

### DIFF
--- a/Jellyfin.sln
+++ b/Jellyfin.sln
@@ -97,6 +97,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Abstractions", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.CoreDefaults", "src\Jellyfin.CoreDefaults\Jellyfin.CoreDefaults.csproj", "{44444444-AAAA-BBBB-CCCC-444444444444}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestOverridePlugin", "plugins\TestOverridePlugin\TestOverridePlugin.csproj", "{55555555-AAAA-BBBB-CCCC-555555555555}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PluginOverrideTests", "tests\PluginOverrideTests\PluginOverrideTests.csproj", "{66666666-AAAA-BBBB-CCCC-666666666666}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -267,6 +271,14 @@ Global
 		{44444444-AAAA-BBBB-CCCC-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44444444-AAAA-BBBB-CCCC-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44444444-AAAA-BBBB-CCCC-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55555555-AAAA-BBBB-CCCC-555555555555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55555555-AAAA-BBBB-CCCC-555555555555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55555555-AAAA-BBBB-CCCC-555555555555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55555555-AAAA-BBBB-CCCC-555555555555}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66666666-AAAA-BBBB-CCCC-666666666666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66666666-AAAA-BBBB-CCCC-666666666666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66666666-AAAA-BBBB-CCCC-666666666666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66666666-AAAA-BBBB-CCCC-666666666666}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -300,6 +312,7 @@ Global
 		{8C9F9221-8415-496C-B1F5-E7756F03FA59} = {4C54CE05-69C8-48FA-8785-39F7F6DB1CAD}
 		{33333333-AAAA-BBBB-CCCC-333333333333} = {C9F0AB5D-F4D7-40C8-A353-3305C86D6D4C}
 		{44444444-AAAA-BBBB-CCCC-444444444444} = {C9F0AB5D-F4D7-40C8-A353-3305C86D6D4C}
+		{66666666-AAAA-BBBB-CCCC-666666666666} = {FBBB5129-006E-4AD7-BAD5-8B7CA1D10ED6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3448830C-EBDC-426C-85CD-7BBB9651A7FE}

--- a/plugins/TestOverridePlugin/MockTranscoderService.cs
+++ b/plugins/TestOverridePlugin/MockTranscoderService.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Abstractions.Services;
+using Microsoft.Extensions.Logging; // Added for potential logging
+
+namespace TestOverridePlugin
+{
+    public class MockTranscoderService : ITranscoderService
+    {
+        private readonly ILogger<MockTranscoderService> _logger;
+
+        // Constructor that might take ILogger if available from plugin's DI scope (if any)
+        public MockTranscoderService(ILogger<MockTranscoderService> logger)
+        {
+            _logger = logger;
+            _logger.LogInformation("MockTranscoderService instantiated.");
+        }
+
+        public Task<TranscodingJobInfo> GetTranscodingJobInfoAsync(TranscodingJobInfoArgs args)
+        {
+            _logger.LogInformation("MockTranscoderService: GetTranscodingJobInfoAsync called for PlaySessionId: {PlaySessionId}", args.PlaySessionId);
+            return Task.FromResult(new TranscodingJobInfo { Id = args.PlaySessionId ?? "mock_job_id", State = "Mocked", Progress = 50.0 });
+        }
+
+        public Task KillTranscodingJobsAsync(string deviceId, string playSessionId)
+        {
+            _logger.LogInformation("MockTranscoderService: KillTranscodingJobsAsync called for DeviceId: {DeviceId}, PlaySessionId: {PlaySessionId}", deviceId, playSessionId);
+            return Task.CompletedTask;
+        }
+
+        public Task<TranscodingJobInfo> StartTranscodingAsync(TranscodingTaskOptions options)
+        {
+            _logger.LogInformation("MockTranscoderService: StartTranscodingAsync called for Input: {InputPath}, Output: {OutputPath}", options.InputPath, options.OutputPath);
+            return Task.FromResult(new TranscodingJobInfo { Id = "mock_job_id_started", State = "MockedStart", Progress = 0.0 });
+        }
+
+        public Task ReportTranscodingProgressAsync(ReportTranscodingProgressArgs progressArgs)
+        {
+            _logger.LogInformation("MockTranscoderService: ReportTranscodingProgressAsync called for JobId: {JobId}, Percent: {PercentComplete}", progressArgs.JobId, progressArgs.PercentComplete);
+            return Task.CompletedTask;
+        }
+
+        public Task PingTranscodingJobAsync(string playSessionId, bool? isUserPaused)
+        {
+            _logger.LogInformation("MockTranscoderService: PingTranscodingJobAsync called for PlaySessionId: {PlaySessionId}, Paused: {IsUserPaused}", playSessionId, isUserPaused);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/plugins/TestOverridePlugin/Plugin.cs
+++ b/plugins/TestOverridePlugin/Plugin.cs
@@ -1,0 +1,95 @@
+using System;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Controller; // For IServerApplicationHost
+using MediaBrowser.Model.Plugins;
+using Jellyfin.Abstractions.Services; // For IServiceOverrideHost and ITranscoderService
+using Microsoft.Extensions.DependencyInjection; // For GetService
+using Microsoft.Extensions.Logging; // For ILogger
+
+namespace TestOverridePlugin
+{
+    public class Plugin : IPlugin
+    {
+        public string Name => "Test Override Plugin";
+        public string Description => "A plugin to test overriding core services.";
+        public Guid Id => Guid.Parse("12345678-1234-1234-1234-1234567890AB"); // Unique GUID for this plugin
+        public Version Version => new Version("1.0.0.0");
+        public string AssemblyFilePath { get; private set; }
+        public bool CanUninstall => true;
+        public string DataFolderPath { get; private set; }
+
+        private readonly IServerApplicationHost _appHost;
+        private readonly ILogger<Plugin> _logger;
+
+        // Constructor will be called by the PluginManager.
+        // We need IServerApplicationHost to get IServiceOverrideHost.
+        // ILogger for logging.
+        public Plugin(IServerApplicationHost appHost, ILogger<Plugin> logger)
+        {
+            _appHost = appHost ?? throw new ArgumentNullException(nameof(appHost));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger.LogInformation("TestOverridePlugin: Constructor called.");
+
+            RegisterOverride();
+        }
+
+        private void RegisterOverride()
+        {
+            try
+            {
+                var serviceOverrideHost = _appHost.ServiceProvider.GetService<IServiceOverrideHost>();
+                if (serviceOverrideHost != null)
+                {
+                    // Need an ILoggerFactory to create ILogger for MockTranscoderService
+                    var loggerFactory = _appHost.ServiceProvider.GetService<ILoggerFactory>();
+                    if (loggerFactory == null) {
+                        _logger.LogError("TestOverridePlugin: Could not get ILoggerFactory to create logger for MockTranscoderService.");
+                        // Optionally, create MockTranscoderService without logger or handle error
+                        return;
+                    }
+                    var mockLogger = loggerFactory.CreateLogger<MockTranscoderService>();
+                    var mockTranscoder = new MockTranscoderService(mockLogger);
+
+                    serviceOverrideHost.RegisterOverride<ITranscoderService>(mockTranscoder);
+                    _logger.LogInformation("TestOverridePlugin: Successfully registered MockTranscoderService override.");
+                }
+                else
+                {
+                    _logger.LogError("TestOverridePlugin: IServiceOverrideHost not found. Cannot register override.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "TestOverridePlugin: Error during service override registration.");
+            }
+        }
+
+        public PluginInfo GetPluginInfo()
+        {
+            return new PluginInfo
+            {
+                Name = this.Name,
+                Description = this.Description,
+                Id = this.Id,
+                Version = this.Version.ToString(),
+                CanUninstall = this.CanUninstall,
+                DataFolderPath = this.DataFolderPath
+            };
+        }
+
+        public void OnUninstalling() { }
+
+        // Required by IPluginAssembly (which BasePlugin implements, but IPlugin might be used directly by PluginManager)
+        public void SetAttributes(string assemblyFilePath, string dataFolderPath, Version assemblyVersion)
+        {
+            AssemblyFilePath = assemblyFilePath;
+            DataFolderPath = dataFolderPath;
+            // Version is already set
+        }
+
+        public void SetId(Guid id)
+        {
+            // Id is already set
+        }
+    }
+}

--- a/plugins/TestOverridePlugin/TestOverridePlugin.csproj
+++ b/plugins/TestOverridePlugin/TestOverridePlugin.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Output path for plugins is usually a specific 'plugins' directory structure -->
+    <OutputPath>../../bin/plugins/TestOverridePlugin/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Reference the Jellyfin.Abstractions project -->
+    <ProjectReference Include="..\..\src\Jellyfin.Abstractions\Jellyfin.Abstractions.csproj" />
+    <!-- Reference MediaBrowser.Common for IPlugin -->
+    <ProjectReference Include="..\..\MediaBrowser.Common\MediaBrowser.Common.csproj" />
+    <!-- Reference MediaBrowser.Controller for IServerApplicationHost (if needed directly by plugin) -->
+    <ProjectReference Include="..\..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
+     <!-- Reference Microsoft.Extensions.DependencyInjection.Abstractions for IServiceCollection (if needed) -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/plugins/TestOverridePlugin/plugin.json
+++ b/plugins/TestOverridePlugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "Id": "TestOverridePlugin",
+  "Name": "Test Override Plugin",
+  "Version": "1.0.0.0",
+  "TargetVersion": "10.9.0.0",
+  "AssemblyName": "TestOverridePlugin.dll",
+  "EntryPoint": "TestOverridePlugin.Plugin"
+}

--- a/tests/PluginOverrideTests/PluginOverrideTests.csproj
+++ b/tests/PluginOverrideTests/PluginOverrideTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable> <!-- This is a test project -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Moq" /> <!-- Adding Moq for mocking dependencies -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the abstractions, core defaults, and the test plugin -->
+    <ProjectReference Include="..\..\src\Jellyfin.Abstractions\Jellyfin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Jellyfin.CoreDefaults\Jellyfin.CoreDefaults.csproj" />
+    <ProjectReference Include="..\..\plugins\TestOverridePlugin\TestOverridePlugin.csproj" />
+    <!-- Reference MediaBrowser.Controller for IServerApplicationHost if TestPlugin needs it -->
+    <ProjectReference Include="..\..\MediaBrowser.Controller\MediaBrowser.Controller.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PluginOverrideTests/ServiceOverrideTest.cs
+++ b/tests/PluginOverrideTests/ServiceOverrideTest.cs
@@ -1,0 +1,102 @@
+using System;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Jellyfin.Abstractions.Services;
+using Jellyfin.CoreDefaults.Services; // For ServiceOverrideHost
+using Jellyfin.CoreDefaults.Transcoding; // For default TranscodeManager
+using TestOverridePlugin; // For MockTranscoderService and Plugin
+using Moq; // For mocking
+using MediaBrowser.Controller; // For IServerApplicationHost
+using Microsoft.Extensions.Logging;
+
+namespace PluginOverrideTests
+{
+    public class ServiceOverrideTest
+    {
+        [Fact]
+        public void TestPlugin_Overrides_ITranscoderService_Successfully()
+        {
+            var services = new ServiceCollection();
+
+            // 1. Register IServiceOverrideHost
+            services.AddSingleton<IServiceOverrideHost, ServiceOverrideHost>();
+
+            // 2. Register default ITranscoderService using the factory pattern
+            // This mimics Startup.cs but uses the concrete types for clarity in test
+            services.AddSingleton<ITranscoderService>(serviceProvider =>
+            {
+                var overrideHost = serviceProvider.GetRequiredService<IServiceOverrideHost>();
+                if (overrideHost.HasOverride<ITranscoderService>())
+                {
+                    return overrideHost.GetOverride<ITranscoderService>();
+                }
+                // For testing, we might not need full ActivatorUtilities if TranscodeManager has many deps.
+                // Instead, we can ensure it's attempted to be created if not overridden.
+                // Here, we'll assume we can create it or mock its creation if it's complex.
+                // For this test, if it's not overridden, we could even return null or a specific marker.
+                // However, to be closer to reality, let's try to use ActivatorUtilities.
+                // This means TranscodeManager and its dependencies must be resolvable by this test ServiceProvider.
+                // This can get complex. A simpler test might directly check ServiceOverrideHost.
+                try
+                {
+                    return ActivatorUtilities.CreateInstance<TranscodeManager>(serviceProvider);
+                }
+                catch (Exception ex)
+                {
+                    // If TranscodeManager can't be created due to missing deps in this minimal setup,
+                    // it's okay for this specific test, as long as the override happens.
+                    Console.WriteLine($"Could not create default TranscodeManager in test: {ex.Message}. This is acceptable if override works.");
+                    return null;
+                }
+            });
+
+            // Add minimal dependencies for TranscodeManager if ActivatorUtilities is to succeed
+            // This is where it gets tricky for a *minimal* DI container.
+            // For now, we rely on the override happening, so default creation failure is logged but tolerated.
+            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            mockLoggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+            services.AddSingleton<ILoggerFactory>(mockLoggerFactory.Object);
+            // Add other critical dependencies for TranscodeManager if known and simple, otherwise rely on override.
+
+
+            // 3. Mock IServerApplicationHost and its ServiceProvider for the Plugin
+            var mockAppHostServiceProvider = new Mock<IServiceProvider>();
+            mockAppHostServiceProvider.Setup(sp => sp.GetService(typeof(IServiceOverrideHost)))
+                .Returns(services.BuildServiceProvider().GetService<IServiceOverrideHost>()); // Use the host from our test container
+            mockAppHostServiceProvider.Setup(sp => sp.GetService(typeof(ILoggerFactory)))
+                .Returns(mockLoggerFactory.Object);
+
+
+            var mockAppHost = new Mock<IServerApplicationHost>();
+            mockAppHost.Setup(ah => ah.ServiceProvider).Returns(mockAppHostServiceProvider.Object);
+
+            // 4. Instantiate the plugin (this should register the override)
+            var pluginLogger = new Mock<ILogger<TestOverridePlugin.Plugin>>().Object;
+            try
+            {
+                var testPlugin = new TestOverridePlugin.Plugin(mockAppHost.Object, pluginLogger);
+            }
+            catch (Exception ex)
+            {
+                // This can happen if the plugin's constructor tries to resolve something not mocked
+                 Console.WriteLine($"Error instantiating plugin (might be ok if override host was still called): {ex.Message}");
+            }
+
+
+            // 5. Build the main service provider for the test
+            var serviceProvider = services.BuildServiceProvider();
+
+            // 6. Resolve ITranscoderService
+            var resolvedTranscoderService = serviceProvider.GetService<ITranscoderService>();
+
+            // 7. Assert that the resolved service is the mock implementation
+            Assert.NotNull(resolvedTranscoderService);
+            Assert.IsType<MockTranscoderService>(resolvedTranscoderService);
+
+            // Optional: Call a method on the mock to see if it logs as expected
+            var mockService = resolvedTranscoderService as MockTranscoderService;
+            mockService?.PingTranscodingJobAsync("test-session", false).GetAwaiter().GetResult();
+            // (Check logs or add a property to MockTranscoderService to verify call)
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a test plugin (`TestOverridePlugin`) and a corresponding test project (`PluginOverrideTests`) to validate the recently implemented pluggable service architecture.

Key additions:
1.  **`TestOverridePlugin` (`plugins/TestOverridePlugin`):**
    *   A new plugin project designed to override the `ITranscoderService`.
    *   Contains `MockTranscoderService.cs` which provides a mock
        implementation of `ITranscoderService`.
    *   The main `Plugin.cs` class attempts to register this mock service
        using `IServiceOverrideHost` upon plugin instantiation.
    *   Includes `plugin.json` manifest and a `.csproj` file targeting
        `net8.0`.

2.  **`PluginOverrideTests` (`tests/PluginOverrideTests`):**
    *   A new xUnit test project.
    *   Contains `ServiceOverrideTest.cs` with a test method
        `TestPlugin_Overrides_ITranscoderService_Successfully`.
    *   This test aims to:
        *   Set up a minimal DI service provider.
        *   Register `IServiceOverrideHost` and the default `ITranscoderService`
            (using the factory pattern established in previous commits).
        *   Simulate the loading of `TestOverridePlugin`.
        *   Resolve `ITranscoderService` and assert that it is the
            `MockTranscoderService` provided by the plugin.
    *   Includes a `.csproj` file targeting `net8.0` with references to
        testing frameworks and relevant solution projects.

3.  **Solution File Update:**
    *   `Jellyfin.sln` has been updated to include both
        `TestOverridePlugin.csproj` and `PluginOverrideTests.csproj`.

**Important Note on Build Status:**
These changes were made with the knowledge of a persistent, underlying compilation error (CS1503 in `MediaBrowser.Common/Net/NetworkUtils.cs`). As such, these new projects, along with the previously refactored `Jellyfin.Abstractions` and `Jellyfin.CoreDefaults` projects, cannot be compiled and tested in the current automated environment until that root issue is resolved.

The purpose of this commit is to establish the complete structure and initial code for testing the pluggable services framework, assuming the build blocker will be addressed separately.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
